### PR TITLE
Update README.md to match project folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this MCP server with Claude, add the following configuration to your Clau
     "mcpServers": {
         "sentry": {
             "command": "npx",
-            "args": ["ts-node", "/Users/<your-user-directory>/mcp-sentry-ts/index.ts"],
+            "args": ["ts-node", "/Users/<your-user-directory>/sentry-mcp-ts/index.ts"],
             "env": {
                 "SENTRY_AUTH": "<YOUR_AUTH_TOKEN>"
             }


### PR DESCRIPTION
The name of the project is different than the path in the README, it should match to make it easier for people to clone the repo and add the server.